### PR TITLE
feat: optional file hash

### DIFF
--- a/carnival.py
+++ b/carnival.py
@@ -3,10 +3,19 @@ import click
 from src.file_scan import FileScan
 
 
+@click.option(
+    "--no-fhash",
+    "no_file_hash",
+    is_flag=True,
+    help="Does not compute file hashes (improve performance)",
+)
 @click.argument("directory", type=click.Path(exists=True))
 @click.command()
-def scan(directory: str):
-    file_scan = FileScan(directory)
+def scan(directory: str, no_file_hash: bool):
+    """
+    DIRECTORY path to the scanned directory
+    """
+    file_scan = FileScan(directory, no_file_hash)
     print(file_scan)
 
 

--- a/src/file_infos.py
+++ b/src/file_infos.py
@@ -5,4 +5,4 @@ from dataclasses import dataclass
 class FileInfo:
     path: str
     size_bytes: int
-    hash: str
+    hash: str | None

--- a/src/file_scan.py
+++ b/src/file_scan.py
@@ -10,7 +10,7 @@ class FileScan:
     def files(self):
         return self._files
 
-    def __init__(self, directory: str):
+    def __init__(self, directory: str, no_file_hash: bool):
         self._directory = directory
         self._files = []
         dir_path = Path(directory)
@@ -19,11 +19,14 @@ class FileScan:
         for path in dir_path.glob("**/*"):
             if path.is_dir():
                 continue
+            file_hash = None
+            if not no_file_hash:
+                file_hash = hasher.hash(path)
             self._files.append(
                 FileInfo(
                     path=str(path.relative_to(dir_path)),
                     size_bytes=os.path.getsize(path.absolute()),
-                    hash=hasher.hash(path),
+                    hash=file_hash,
                 )
             )
 


### PR DESCRIPTION
Add CLI option `--no-fhash` to command `scan` for skipping the computation of file MD5 hashes while scanning.